### PR TITLE
Fix npm package version v1.0.0 => v1.0.1 #39

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabbouleh",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "JSON Schema generator from TypeScript classes, in runtime",
   "keywords": [
     "typescript",


### PR DESCRIPTION
`npm publish` fail because the `v1.0.0` was already used by a removed release.
Switch to `v1.0.1`.